### PR TITLE
Rubocop Cleanup / ChefSpec matchers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,11 @@
 AllCops:
-  Includes:
+  Include:
     - Berksfile
     - Gemfile
     - Rakefile
     - Thorfile
     - Guardfile
-  Excludes:
+  Exclude:
     - vendor/**
 
 ClassLength:
@@ -22,7 +22,7 @@ MethodLength:
   Enabled: false
 SignalException:
   Enabled: false
-TrailingComma:
+Style/TrailingCommaInLiteral:
   Enabled: false
 WordArray:
   Enabled: false

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,21 @@
+if defined?(ChefSpec)
+  def save_modules(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:modules, :save, resource_name)
+  end
+
+  def load_modules(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:modules, :load, resource_name)
+  end
+
+  def remove_modules(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:modules, :remove, resource_name)
+  end
+
+  def save_modules_multi(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:modules_multi, :save, resource_name)
+  end
+
+  def remove_modules_multi(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:modules_multi, :remove, resource_name)
+  end
+end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -23,7 +23,6 @@ use_inline_resources
 include Chef::DSL::IncludeRecipe
 
 action :save do
-
   include_recipe 'modules::config'
 
   file path do

--- a/providers/multi.rb
+++ b/providers/multi.rb
@@ -23,7 +23,6 @@ use_inline_resources
 include Chef::DSL::IncludeRecipe
 
 action :save do
-
   include_recipe 'modules::config'
 
   template path do
@@ -33,7 +32,7 @@ action :save do
     mode '0644'
     variables(
       :modules => new_resource.modules
-      )
+    )
     notifies :restart, 'service[modules-load]', :immediately
     only_if { supported? }
   end

--- a/recipes/_systemd.rb
+++ b/recipes/_systemd.rb
@@ -1,15 +1,14 @@
-%w[module-init-tools modules-load].each do |f|
-
+%w(module-init-tools modules-load).each do |f|
   cookbook_file "/usr/local/bin/#{f}.sh" do
     mode 0770
-    owner "root"
-    group "root"
+    owner 'root'
+    group 'root'
   end
 
   cookbook_file "/etc/systemd/system/#{f}.service" do
     mode 0644
-    owner "root"
-    group "root"
+    owner 'root'
+    group 'root'
     source "#{f}.systemd"
   end
 end
@@ -22,15 +21,15 @@ file '/etc/modules-load.d/modules.conf' do
   only_if { platform?('debian') }
 end
 
-service "module-init-tools" do
+service 'module-init-tools' do
   provider Chef::Provider::Service::Systemd
   action [:enable, :start]
 end
 
-service "modules-load" do
+service 'modules-load' do
   provider Chef::Provider::Service::Systemd
   action [:enable, :start]
-  notifies :restart, "service[module-init-tools]", :immediately
+  notifies :restart, 'service[module-init-tools]', :immediately
 end
 
 template '/etc/modules-load.d/chef-default.conf' do

--- a/recipes/_upstart.rb
+++ b/recipes/_upstart.rb
@@ -34,4 +34,3 @@ template '/etc/modules-load.d/chef-default.conf' do
   notifies :restart, 'service[modules-load]', :immediately
   only_if { node['modules']['default']['modules'] }
 end
-

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -38,4 +38,3 @@ end
 
 # include init job
 include_recipe "modules::_#{node['modules']['init']}"
-

--- a/recipes/install_attributes.rb
+++ b/recipes/install_attributes.rb
@@ -27,6 +27,6 @@ template '/etc/modules-load.d/chef-attibutes.conf' do
   variables(
     :modules => node['modules']['modules']
   )
-  notifies :restart, "service[modules-load]", :immediately
+  notifies :restart, 'service[modules-load]', :immediately
   only_if { node['modules']['modules'] }
 end


### PR DESCRIPTION
This allows us to use chefspec on the module resource in other cookbooks.