### PR TITLE
Support ubuntu 16.04, and all systemd-based ubuntus

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,7 @@ driver_config:
 platforms:
 - name: ubuntu-12.04
 - name: ubuntu-14.04
+- name: ubuntu-16.04
 - name: centos-6.6
 - name: centos-7.1
 - name: fedora-20

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,10 @@ default['modules']['init'] = value_for_platform(
   'debian' => {
     '~> 8.0' => 'systemd'
   },
+  'ubuntu' => {
+    '< 15.04' => 'upstart',
+    '>= 15.04' => 'systemd'
+  },
   'default' => 'upstart')
 default['modules']['packages'] = value_for_platform(
   'debian' => {

--- a/recipes/_systemd.rb
+++ b/recipes/_systemd.rb
@@ -18,7 +18,7 @@ end
 file '/etc/modules-load.d/modules.conf' do
   action :delete
   backup false
-  only_if { platform?('debian') }
+  only_if { platform?('debian') || platform?('ubuntu') }
 end
 
 service 'module-init-tools' do


### PR DESCRIPTION
# What

Ubuntu 15.04 and above moved from upstart to systemd. This cookbook fails needlessly on these newer ubuntu platforms, so let's teach it to support this change.

# How

We add a case stating that ubuntu's older than 15.04 use upstart, and newer than 15.04 use systemd to the attributes file.

Also, there is another instance where the behavior is specific to the 'debian' family, but that now also includes ubuntu (which has capitulated and gone with systemd in lieu of upstart)